### PR TITLE
Docker-Compose file improvements for services 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,9 @@ services:
     entrypoint:
       - "/bin/sh"
       - "-c"
-      - "/bin/echo 'postgres:5432:*:postgres:behappy' > /tmp/pgpassfile && chmod 600 /tmp/pgpassfile && /entrypoint.sh"  
+      - "/bin/echo 'postgres:5432:*:postgres:behappy' > /tmp/pgpassfile && chmod 600 /tmp/pgpassfile && /entrypoint.sh" 
+    depends_on:
+      - postgres
   pynb:
     container_name: pynb_container
     image: sbruce23/pynb_image:1.1


### PR DESCRIPTION
# Code Triage

Adding Check flags for Services of docker-compose.yml:

* **depends_on** option is used to define the dependency between services, indicating that one service depends on another.

* Startup Order: When you run docker-compose up, Docker Compose will start the postgres container first, before starting the pgadmin container. This order is crucial because pgadmin is a PostgreSQL administration interface and will need a running PostgreSQL server (in this case, the postgres service) to function correctly. 
